### PR TITLE
Correct Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Use the following code to draw a file from svg file, insted of tracing full imag
     
 ```
     from sketchpy import canvas
-    obj = canvas.draw_from_svg('FILE PATH')
+    obj = canvas.sketch_from_svg('FILE PATH')
     obj.draw()
 ```
     


### PR DESCRIPTION
It seems that ```draw_from_svg``` is ```sketch_from_svg```, It was tested and Draw from SVG does not work. Kindly get the ReadMe fixed.