### PR TITLE
Solved a line of code in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ use the following code to draw any image, it need not to be an svg file
 ```
     from sketchpy import canvas
     obj = canvas.sketch_from_image('IMAGE PATH')
-    obj = draw(threshold = 127)
+    obj.draw(threshold = 127)
 ```
 #### NOTE: you can change the value of threshold to draw more detailed image, it's range is 0 - 255,use values between 90-190
 


### PR DESCRIPTION
In code example of "drawing image from `raw image`", there was a line `obj = draw(threshold = 127)`.. 
This line is changed to: `obj.draw(threshold = 127)` to solve "name `draw ` not defined" error.